### PR TITLE
(Forge 1.19.4) Fixed clients without WorldEdit not being able to join servers with WorldEdit installed

### DIFF
--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/handler/PacketHandlerUtil.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/handler/PacketHandlerUtil.java
@@ -42,7 +42,7 @@ final class PacketHandlerUtil {
     private static Predicate<String> validateLenient(String protocolVersion) {
         return remoteVersion ->
             protocolVersion.equals(remoteVersion)
-                || NetworkRegistry.ABSENT.equals(remoteVersion)
+                || NetworkRegistry.ABSENT.version().equals(remoteVersion)
                 || NetworkRegistry.ACCEPTVANILLA.equals(remoteVersion);
     }
 }


### PR DESCRIPTION
During the 1.19.4 port of Forge, the absent version marker `NetworkRegistry.ABSENT`, which used to be of type `String`, has been changed to now be a `ChannelData` instance. This causes problems due to `.equals()` checks with the version marker and incoming versions, which worked in Forge for 1.19.3, now always failing due to two different objects being compared. In this specific case, it leads to clients without WorldEdit installed not being able to join Forge servers with WorldEdit installed due to the `validateLenient` method checking inappropriately whether the version is the `ABSENT` string, and thus the client connection getting rejected due to mismatching channel versions.
This PR fixes this issue by adding a .version() call to the affected check, ensuring that the incoming version is compared to the actual "Absent" version string instead of the ChannelData object.